### PR TITLE
Fix .NET SDK version in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,9 @@ jobs:
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.305
+        dotnet-version: 8.0
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe


### PR DESCRIPTION
Hey, I noticed that for a while there haven't been any new NuGet packages published.
It seems like the publish.yml GitHub action is failing because it's using .NET 7 SDK instead of .NET 8.

Unfortunately, I can't test whether this actually fixes the build error in the GitHub action, because I can't run it.