### PR TITLE
Fix README, add RdpControl.OnClientAreaClicked event and fix InvalidActiveXStateException in RdpControl.Disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# FreeRDP Control
+# RDP Control
 
-[![NuGet Version](https://img.shields.io/nuget/v/RoyalApps.Community.Rdp.WinForms.svg?style=flat)](https://www.nuget.org/packages/RoyalApps.Community.FreeRdp.WinForms)
-[![NuGet Downloads](https://img.shields.io/nuget/dt/RoyalApps.Community.Rdp.WinForms.svg?color=green)](https://www.nuget.org/packages/RoyalApps.Community.FreeRdp.WinForms)
-[![.NET](https://img.shields.io/badge/.NET-%3E%3D%20%207.0-blueviolet)](https://dotnet.microsoft.com/download)
+[![NuGet Version](https://img.shields.io/nuget/v/RoyalApps.Community.Rdp.WinForms.svg?style=flat)](https://www.nuget.org/packages/RoyalApps.Community.Rdp.WinForms)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/RoyalApps.Community.Rdp.WinForms.svg?color=green)](https://www.nuget.org/packages/RoyalApps.Community.Rdp.WinForms)
+[![.NET](https://img.shields.io/badge/.NET-%3E%3D%20%208.0-blueviolet)](https://dotnet.microsoft.com/download)
 
 RoyalApps.Community.RDP contains projects/packages to easily embed/use Microsoft RDP ActiveX wrapped in [MsRdpEx](https://github.com/Devolutions/MsRdpEx) in a Windows (WinForms) application.
 ![Screenshot](https://raw.githubusercontent.com/royalapplications/royalapps-community-rdp/main/docs/assets/Screenshot.png)
 
 ## Getting Started
 ### Installation
-You should install the RoyalApps.Community.FreeRDP.WinForms with NuGet:
+You should install the RoyalApps.Community.RDP.WinForms with NuGet:
 ```
 Install-Package RoyalApps.Community.RDP.WinForms
 ```
@@ -18,7 +18,7 @@ or via the command line interface:
 dotnet add package RoyalApps.Community.RDP.WinForms
 ```
 
-### Using the FreeRdpControl
+### Using the RdpControl
 #### Add Control
 Place the `RdpControl` on a form or in a container control (user control, tab control, etc.) and set the `Dock` property to `DockStyle.Fill`
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpControl.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpControl.cs
@@ -86,7 +86,12 @@ public class RdpControl : UserControl
     /// <summary>
     /// Raised when the client calls the RequestClose method.
     /// </summary>
-    public event EventHandler<IMsTscAxEvents_OnConfirmCloseEvent>? OnConfirmClose; 
+    public event EventHandler<IMsTscAxEvents_OnConfirmCloseEvent>? OnConfirmClose;
+
+    /// <summary>
+    /// This event is raised when a user clicks into a remote desktop session and DisableClickDetection is not set. 
+    /// </summary>
+    public event EventHandler? OnClientAreaClicked;
 
     /// <summary>
     /// Raised before the remote desktop size is going to change.
@@ -171,6 +176,7 @@ public class RdpControl : UserControl
         RdpClient.OnRequestContainerMinimize -= RdpClient_OnRequestContainerMinimize;
         RdpClient.OnRequestLeaveFullScreen -= RdpClient_OnRequestLeaveFullScreen;
         RdpClient.OnConfirmClose -= RdpClient_OnConfirmClose;
+        RdpClient.OnClientAreaClicked -= RdpClient_OnClientAreaClicked;
     }
 
     /// <summary>
@@ -496,6 +502,11 @@ public class RdpControl : UserControl
         OnConfirmClose?.Invoke(sender, e);
     }
 
+    private void RdpClient_OnClientAreaClicked(object? sender, EventArgs e)
+    {
+        OnClientAreaClicked?.Invoke(sender, e);
+    }
+
     private void ApplyInitialScaling()
     {
         _currentZoomLevel = RdpConfiguration.Display.AutoScaling 
@@ -624,6 +635,7 @@ public class RdpControl : UserControl
         RdpClient.OnRequestContainerMinimize += RdpClient_OnRequestContainerMinimize;
         RdpClient.OnRequestLeaveFullScreen += RdpClient_OnRequestLeaveFullScreen;
         RdpClient.OnConfirmClose += RdpClient_OnConfirmClose;
+        RdpClient.OnClientAreaClicked += RdpClient_OnClientAreaClicked;
     }
 
     private bool SetZoomLevel(int desiredZoomLevel)

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpControl.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpControl.cs
@@ -199,7 +199,7 @@ public class RdpControl : UserControl
     /// </summary>
     public void Disconnect()
     {
-        if (RdpClient == null || RdpClient.ConnectionState == ConnectionState.Disconnected) 
+        if (RdpClient == null || RdpClient.GetOcx() == null || RdpClient.ConnectionState == ConnectionState.Disconnected) 
             return;
 
         try


### PR DESCRIPTION
Hey, just some small things I noticed while using the library.

* The README referenced your other package for FreeRDP in some places.
* I also noticed that there was no RdpControl.OnClientAreaClicked event, but all other events of the RdpClient are available through the RdpControl (Connected, Disconnected, etc.)
* And I also experienced a InvalidActiveXStateException in RdpControl.Disconnect() method when the underlying Ocx control was still NULL. The code in that method seems very defensive, so this additional check makes sense to avoid the exception.

Just some small things, but would be appreciated if you could merge it 😄 