### PR TITLE
In publish.yml only run nuget-push on the main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,7 @@ jobs:
         
     # Push nuget package to nuget.org
     - name: nuget push
+      if: github.ref == 'refs/heads/main'
       run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
       env:
         Configuration: ${{ matrix.configuration }}


### PR DESCRIPTION
New nuget packages can only be pushed from the main branch anyways, and not from PR runs.

This little change ensures that PR runs can now be successful.
Until now, they would always fail on the nuget push.