### PR TITLE
Strip UTF-8 BOM from source files

### DIFF
--- a/src/RoyalApps.Community.Rdp.WinForms.Demo/RdpForm.Designer.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms.Demo/RdpForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.Demo;
+namespace RoyalApps.Community.Rdp.Demo;
 
 partial class RdpForm
 {

--- a/src/RoyalApps.Community.Rdp.WinForms.Demo/RoyalApps.Community.Rdp.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.Rdp.WinForms.Demo/RoyalApps.Community.Rdp.WinForms.Demo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/AudioRedirectionMode.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/AudioRedirectionMode.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Specifies the audio redirection settings, which specify whether to redirect sounds or play sounds at the Remote Desktop Session Host (RD Session Host) server.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/AuthenticationLevel.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/AuthenticationLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Specifies the authentication level to use for the connection.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/ClientProtocolSpec.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/ClientProtocolSpec.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Specifies the remote desktop protocol used between the client and the server.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/ColorDepth.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/ColorDepth.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Remote Desktop Color Depth

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/ConnectionConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/ConnectionConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/CredentialConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/CredentialConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/DisplayConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/DisplayConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayCredsSource.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayCredsSource.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Specifies or retrieves the Remote Desktop Gateway (RD Gateway) authentication method.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayProfileUsageMethod.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayProfileUsageMethod.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Specifies whether to use default Remote Desktop Gateway (RD Gateway) settings.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayUsageMethod.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/GatewayUsageMethod.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Specifies when to use a Remote Desktop Gateway (RD Gateway) server.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/HyperVConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/HyperVConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/InputConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/InputConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/KeepAliveMethod.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/KeepAliveMethod.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// The method used to perform keep-alive actions

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/NetworkConnectionType.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/NetworkConnectionType.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// The network connection type information passed on to the server helps the server tune several parameters based on the network connection type.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/PerformanceConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/PerformanceConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/ProgramConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/ProgramConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/RdpClientConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/RdpClientConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/RedirectionConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/RedirectionConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/ResizeBehavior.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/ResizeBehavior.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// The behavior when the control is resized.

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/SecurityConfiguration.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/SecurityConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Configuration/SensitiveString.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Configuration/SensitiveString.cs
@@ -1,4 +1,4 @@
-﻿namespace RoyalApps.Community.Rdp.WinForms.Configuration;
+namespace RoyalApps.Community.Rdp.WinForms.Configuration;
 
 /// <summary>
 /// Represents a sensitive string and prevents accidental leaking.

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/ConnectedEventArgs.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/ConnectedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 
 namespace RoyalApps.Community.Rdp.WinForms.Controls;

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/DisconnectedEventArgs.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/DisconnectedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace RoyalApps.Community.Rdp.WinForms.Controls;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/MessageFilter.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/MessageFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 using Windows.Win32;
 using RoyalApps.Community.Rdp.WinForms.Interfaces;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/MsRdpExManager.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/MsRdpExManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using MsRdpEx;
 

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpClient.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using AxMSTSCLib;
 using Microsoft.Extensions.Logging;

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpClientExtensions.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpClientFactory.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpClientFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;

--- a/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpControl.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Controls/RdpControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;

--- a/src/RoyalApps.Community.Rdp.WinForms/Interfaces/IRdpClient.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Interfaces/IRdpClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using AxMSTSCLib;
 using Microsoft.Extensions.Logging;
 using MSTSCLib;

--- a/src/RoyalApps.Community.Rdp.WinForms/Logging/DebugLogger.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms/Logging/DebugLogger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.Extensions.Logging;

--- a/src/RoyalApps.Community.Rdp.slnx
+++ b/src/RoyalApps.Community.Rdp.slnx
@@ -1,4 +1,4 @@
-﻿<Solution>
+<Solution>
   <Folder Name="/Solution Items/">
     <File Path="..\README.md" />
   </Folder>


### PR DESCRIPTION
The byte-order marks are not necessary on any platform -- C#, .NET and current IDEs handle UTF-8 files just fine without them.