### PR TITLE
Add .NET 10 target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/src/RoyalApps.Community.Rdp.WinForms.Demo/RdpForm.cs
+++ b/src/RoyalApps.Community.Rdp.WinForms.Demo/RdpForm.cs
@@ -21,7 +21,7 @@ public partial class RdpForm : Form
             FormBorderStyle = FormBorderStyle.SizableToolWindow,
             StartPosition = FormStartPosition.CenterParent
         };
-        _form.Closing += (_, args) =>
+        _form.FormClosing += (_, args) =>
         {
             _form.Hide();
             args.Cancel = true;

--- a/src/RoyalApps.Community.Rdp.WinForms.Demo/RoyalApps.Community.Rdp.WinForms.Demo.csproj
+++ b/src/RoyalApps.Community.Rdp.WinForms.Demo/RoyalApps.Community.Rdp.WinForms.Demo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <Nullable>enable</Nullable>
         <UseWindowsForms>true</UseWindowsForms>
         <RootNamespace>RoyalApps.Community.Rdp.Demo</RootNamespace>

--- a/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
+++ b/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0-windows;net8.0-windows</TargetFrameworks>
+        <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows</TargetFrameworks>
         <RuntimeIdentifier Condition="$(Platform) == 'x64'">win-x64</RuntimeIdentifier>
         <RuntimeIdentifier Condition="$(Platform) == 'ARM64'">win-arm64</RuntimeIdentifier>
         <UseWindowsForms>true</UseWindowsForms>
@@ -42,6 +42,10 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25380.108" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
+++ b/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
@@ -41,11 +41,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.7.25380.108" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25451.107" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Not ready for merging/release yet (RC1 needed for go-live) but sufficient for pre-release testing.

Replace obsolete `From.Closing` event with `Form.FormClosing`