### PR TITLE
Assorted enhancements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
 
     # Upload packages
     - name: Upload managed components
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Rdp-nupkg
         path: ./*.nupkg

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,10 +76,6 @@ jobs:
       with:
         dotnet-version: '10.0.x'
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v2
-
     # Build
     - name: build project
       run: dotnet build -c Release src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NugetAudit>true</NugetAudit>
+    <NugetAuditMode>all</NugetAuditMode>
+    <NugetAuditLevel>low</NugetAuditLevel>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1506</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Devolutions.MsRdpEx" Version="2025.7.25" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.264" />
+  </ItemGroup>
+</Project>

--- a/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
+++ b/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
@@ -15,9 +15,9 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows</TargetFrameworks>
-        <RuntimeIdentifier Condition="$(Platform) == 'x64'">win-x64</RuntimeIdentifier>
-        <RuntimeIdentifier Condition="$(Platform) == 'ARM64'">win-arm64</RuntimeIdentifier>
+        <TargetFramework>net10.0-windows</TargetFramework>
+        <RuntimeIdentifier Condition="'$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+        <RuntimeIdentifier Condition="'$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
         <UseWindowsForms>true</UseWindowsForms>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -29,23 +29,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Devolutions.MsRdpEx" Version="2025.7.25" />
-      <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.259">
+      <PackageReference Include="Devolutions.MsRdpEx" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+      <PackageReference Include="Microsoft.Windows.CsWin32">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
+++ b/src/RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj
@@ -25,7 +25,6 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);CS8981;NU1701</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/RoyalApps.Community.Rdp.slnx
+++ b/src/RoyalApps.Community.Rdp.slnx
@@ -1,7 +1,9 @@
 <Solution>
   <Folder Name="/Solution Items/">
-    <File Path="..\README.md" />
+    <File Path="../LICENSE" />
+    <File Path="../README.md" />
     <File Path=".editorconfig" />
+    <File Path="Directory.Packages.props" />
   </Folder>
   <Project Path="RoyalApps.Community.Rdp.WinForms.Demo\RoyalApps.Community.Rdp.WinForms.Demo.csproj" />
   <Project Path="RoyalApps.Community.Rdp.WinForms\RoyalApps.Community.Rdp.WinForms.csproj" />


### PR DESCRIPTION
Update projects to only target `net10.0`, dropping legacy .NET 9, 8 and Framework.

Enable NuGet Central Package Management (CPM) for consolidated dependency management.

Bump CsWin32.

Bump GH action versions.

Remove unused `setup-msbuild` GH action (building with `dotnet`)