### PR TITLE
Bump dependencies

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,8 +8,8 @@
     <WarningsAsErrors>$(WarningsAsErrors);NU1506</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Devolutions.MsRdpEx" Version="2025.7.25" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Devolutions.MsRdpEx" Version="2026.1.12" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.264" />
   </ItemGroup>
 </Project>

--- a/src/RoyalApps.Community.Rdp.slnx
+++ b/src/RoyalApps.Community.Rdp.slnx
@@ -5,6 +5,6 @@
     <File Path=".editorconfig" />
     <File Path="Directory.Packages.props" />
   </Folder>
-  <Project Path="RoyalApps.Community.Rdp.WinForms.Demo\RoyalApps.Community.Rdp.WinForms.Demo.csproj" />
-  <Project Path="RoyalApps.Community.Rdp.WinForms\RoyalApps.Community.Rdp.WinForms.csproj" />
+  <Project Path="RoyalApps.Community.Rdp.WinForms.Demo/RoyalApps.Community.Rdp.WinForms.Demo.csproj" />
+  <Project Path="RoyalApps.Community.Rdp.WinForms/RoyalApps.Community.Rdp.WinForms.csproj" />
 </Solution>


### PR DESCRIPTION
Bump dependencies (patch Tuesday 2026-01, latest MsRdpEx)

Switch `.slnx` to forward slashes. Rider used backslashes previously, but this recently changed; update to match the current IDE. *(Cosmetic change; no functional impact.)*